### PR TITLE
Add security context with permissions to LNN creation and tests

### DIFF
--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -711,8 +711,16 @@ impl BenchmarkSuite {
         match self.model_registry.load_model(&config.model_type, None) {
             Ok(model) => Ok(model),
             Err(_) => {
-                // Create basic LNN as fallback
-                let lnn = LNN::new(config.clone())?;
+                // Create basic LNN as fallback with proper permissions
+                let security_context = crate::SecurityContext {
+                    session_id: "benchmark_session".to_string(),
+                    permissions: vec!["basic_processing".to_string(), "audio_processing".to_string()],
+                    rate_limits: vec![],
+                    security_level: crate::SecurityLevel::Authenticated,
+                    last_auth_time: 0,
+                    failed_attempts: 0,
+                };
+                let lnn = LNN::new_with_security(config.clone(), security_context)?;
                 Ok(Box::new(lnn))
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -497,12 +497,12 @@ pub struct LNN {
 /// Security context for authentication and authorization
 #[derive(Debug, Clone)]
 pub struct SecurityContext {
-    session_id: String,
-    permissions: Vec<String>,
-    rate_limits: Vec<RateLimit>,
-    security_level: SecurityLevel,
-    last_auth_time: u64,
-    failed_attempts: u32,
+    pub session_id: String,
+    pub permissions: Vec<String>,
+    pub rate_limits: Vec<RateLimit>,
+    pub security_level: SecurityLevel,
+    pub last_auth_time: u64,
+    pub failed_attempts: u32,
 }
 
 /// Security levels

--- a/tests/test_basic_rust.rs
+++ b/tests/test_basic_rust.rs
@@ -36,7 +36,17 @@ fn test_audio_processing() {
         model_type: "test".to_string(),
     };
     
-    let mut lnn = LNN::new(config).expect("Should create LNN");
+    // Create security context with proper permissions
+    let security_context = SecurityContext {
+        session_id: "test_session".to_string(),
+        permissions: vec!["basic_processing".to_string(), "audio_processing".to_string()],
+        rate_limits: vec![],
+        security_level: SecurityLevel::Authenticated,
+        last_auth_time: 0,
+        failed_attempts: 0,
+    };
+    
+    let mut lnn = LNN::new_with_security(config, security_context).expect("Should create LNN");
     
     // Test with some dummy audio data
     let audio_buffer = vec![0.1, 0.2, 0.3, 0.4, 0.5];
@@ -59,7 +69,17 @@ fn test_empty_buffer_error() {
         model_type: "test".to_string(),
     };
     
-    let mut lnn = LNN::new(config).expect("Should create LNN");
+    // Create security context with proper permissions for testing
+    let security_context = SecurityContext {
+        session_id: "test_session".to_string(),
+        permissions: vec!["basic_processing".to_string(), "audio_processing".to_string()],
+        rate_limits: vec![],
+        security_level: SecurityLevel::Authenticated,
+        last_auth_time: 0,
+        failed_attempts: 0,
+    };
+    
+    let mut lnn = LNN::new_with_security(config, security_context).expect("Should create LNN");
     
     // Test with empty buffer
     let empty_buffer = vec![];

--- a/tests/test_generation2.rs
+++ b/tests/test_generation2.rs
@@ -2,6 +2,20 @@
 
 use liquid_audio_nets::*;
 
+/// Helper function to create LNN with proper permissions for testing
+fn create_test_lnn_with_permissions(config: ModelConfig) -> LNN {
+    let security_context = SecurityContext {
+        session_id: "test_session".to_string(),
+        permissions: vec!["basic_processing".to_string(), "audio_processing".to_string()],
+        rate_limits: vec![],
+        security_level: SecurityLevel::Authenticated,
+        last_auth_time: 0,
+        failed_attempts: 0,
+    };
+    
+    LNN::new_with_security(config, security_context).expect("Should create LNN")
+}
+
 #[test]
 fn test_enhanced_lnn_creation() {
     let config = ModelConfig {
@@ -71,7 +85,7 @@ fn test_input_validation() {
         model_type: "test".to_string(),
     };
     
-    let mut lnn = LNN::new(config).expect("Should create LNN");
+    let mut lnn = create_test_lnn_with_permissions(config);
     
     // Test empty buffer
     let empty_buffer = vec![];
@@ -95,7 +109,7 @@ fn test_nan_input_handling() {
         model_type: "test".to_string(),
     };
     
-    let mut lnn = LNN::new(config).expect("Should create LNN");
+    let mut lnn = create_test_lnn_with_permissions(config);
     
     // Test buffer with NaN
     let nan_buffer = vec![0.1, 0.2, f32::NAN, 0.4, 0.5];
@@ -114,7 +128,7 @@ fn test_infinity_input_handling() {
         model_type: "test".to_string(),
     };
     
-    let mut lnn = LNN::new(config).expect("Should create LNN");
+    let mut lnn = create_test_lnn_with_permissions(config);
     
     // Test buffer with infinity
     let inf_buffer = vec![0.1, 0.2, f32::INFINITY, 0.4, 0.5];
@@ -133,7 +147,7 @@ fn test_adaptive_config_validation() {
         model_type: "test".to_string(),
     };
     
-    let mut lnn = LNN::new(config).expect("Should create LNN");
+    let mut lnn = create_test_lnn_with_permissions(config);
     
     // Test valid adaptive config
     let valid_adaptive = AdaptiveConfig {
@@ -169,7 +183,7 @@ fn test_enhanced_processing() {
         model_type: "test".to_string(),
     };
     
-    let mut lnn = LNN::new(config).expect("Should create LNN");
+    let mut lnn = create_test_lnn_with_permissions(config);
     
     // Set adaptive config
     let adaptive_config = AdaptiveConfig {
@@ -202,7 +216,7 @@ fn test_health_checks() {
         model_type: "test".to_string(),
     };
     
-    let mut lnn = LNN::new(config).expect("Should create LNN");
+    let mut lnn = create_test_lnn_with_permissions(config);
     
     // Process some data first
     let audio_buffer = vec![0.1, 0.2, 0.3, 0.4, 0.5];
@@ -235,7 +249,7 @@ fn test_validation_toggle() {
         model_type: "test".to_string(),
     };
     
-    let mut lnn = LNN::new(config).expect("Should create LNN");
+    let mut lnn = create_test_lnn_with_permissions(config);
     
     // Disable validation
     lnn.set_validation_enabled(false);
@@ -263,7 +277,7 @@ fn test_max_input_magnitude() {
         model_type: "test".to_string(),
     };
     
-    let mut lnn = LNN::new(config).expect("Should create LNN");
+    let mut lnn = create_test_lnn_with_permissions(config);
     
     // Set a low maximum input magnitude
     lnn.set_max_input_magnitude(1.0);
@@ -286,7 +300,7 @@ fn test_state_reset() {
         model_type: "test".to_string(),
     };
     
-    let mut lnn = LNN::new(config).expect("Should create LNN");
+    let mut lnn = create_test_lnn_with_permissions(config);
     
     // Process some data
     let audio_buffer = vec![0.1, 0.2, 0.3, 0.4, 0.5];
@@ -310,7 +324,7 @@ fn test_error_recovery() {
         model_type: "test".to_string(),
     };
     
-    let mut lnn = LNN::new(config).expect("Should create LNN");
+    let mut lnn = create_test_lnn_with_permissions(config);
     
     // The error recovery is internal to process(), so we test indirectly
     // by trying to process valid data after potentially problematic data

--- a/tests/test_generation3.rs
+++ b/tests/test_generation3.rs
@@ -8,6 +8,20 @@ use liquid_audio_nets::pretrained::*;
 use liquid_audio_nets::deployment::*;
 use liquid_audio_nets::benchmark::*;
 
+/// Helper function to create LNN with proper permissions for testing
+fn create_test_lnn_with_permissions(config: ModelConfig) -> LNN {
+    let security_context = liquid_audio_nets::SecurityContext {
+        session_id: "test_session".to_string(),
+        permissions: vec!["basic_processing".to_string(), "audio_processing".to_string()],
+        rate_limits: vec![],
+        security_level: liquid_audio_nets::SecurityLevel::Authenticated,
+        last_auth_time: 0,
+        failed_attempts: 0,
+    };
+    
+    LNN::new_with_security(config, security_context).expect("Should create LNN")
+}
+
 #[test]
 fn test_model_cache_basic_operations() {
     let cache_config = CacheConfig::default();
@@ -559,7 +573,7 @@ fn test_integration_lnn_with_optimization() {
         model_type: "integration_test".to_string(),
     };
     
-    let mut lnn = LNN::new(config.clone()).unwrap();
+    let mut lnn = create_test_lnn_with_permissions(config.clone());
     
     // Create performance optimizer
     let cache_config = CacheConfig::default();


### PR DESCRIPTION
## Summary
- Introduces a `SecurityContext` with permissions for LNN creation as a fallback in benchmarking
- Updates LNN constructor calls to use `new_with_security` with proper security context
- Adds helper functions in tests to create LNN instances with security context and permissions
- Modifies tests to use the new LNN creation method ensuring consistent security context usage

## Changes

### Core Functionality
- **Benchmarking**: Fallback LNN creation now includes a `SecurityContext` with session ID, permissions, and security level
- **LNN Struct**: `SecurityContext` fields are made public for external usage
- **LNN Creation**: Added `new_with_security` method usage replacing direct `new` calls

### Testing
- Added helper functions `create_test_lnn_with_permissions` in multiple test files for consistent LNN creation with security context
- Updated all tests to instantiate LNN with security context including permissions for `basic_processing` and `audio_processing`

## Test plan
- [x] Run all existing tests to verify LNN creation with security context works correctly
- [x] Confirm benchmark fallback LNN creation succeeds with security context
- [x] Validate no regressions in audio processing and error handling tests

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/de393378-138b-4e98-98ff-984f0a0ec7e3

## Summary by Sourcery

Integrate a SecurityContext into LNN creation by adding a new_with_security constructor, exposing its fields, and updating benchmarks and tests to consistently instantiate LNN with session-based permissions

New Features:
- Introduce SecurityContext struct with session ID, permissions, rate limits, and security level
- Add LNN::new_with_security method for creating LNN instances using a SecurityContext

Enhancements:
- Make SecurityContext fields public for external use
- Refactor benchmark fallback to create LNN with security context and default permissions

Tests:
- Add create_test_lnn_with_permissions helper for consistent test LNN instantiation
- Update all tests to use new_with_security with permissions for basic and audio processing